### PR TITLE
feat: тесты p2p-request-ов

### DIFF
--- a/API/tests/test_p2p_request.py
+++ b/API/tests/test_p2p_request.py
@@ -1,0 +1,104 @@
+from fastapi.testclient import TestClient
+from httpx import Response
+
+from core.main import app
+from core.config import get_settings
+from core import schemas
+from sql.crud import UserCrud, ScopeCrud, UserToScopeCrud, P2PRequestCrud
+from sql.database import get_db_not_dependency
+from _testing_utils import UserAccessCookie, get_new_discord_id
+
+
+SETTINGS = get_settings()
+
+client = TestClient(app)
+
+
+db = get_db_not_dependency()
+
+for scope_name in SETTINGS.OAUTH2_SCHEME_SCOPES:
+    ScopeCrud(db).create(schemas.ScopeCreate(name=scope_name))
+
+test_p2p_user_create_schema = schemas.UserCreate(
+    username='p2p_user', password='p2p_password', discord_id=next(get_new_discord_id)
+)
+
+test_p2p_user = UserCrud(db).create(test_p2p_user_create_schema)
+
+all_scopes = ScopeCrud(db).get_many()
+
+test_user_scope = all_scopes[2]
+
+UserToScopeCrud(db).create(schemas.UserToScopeCreate(user_id=test_p2p_user.id, scope_id=test_user_scope.id))
+
+test_p2p_request_create_schema = schemas.P2PRequestCreate(
+    repository_link='https://test-link', comment='test comment', creator_id=test_p2p_user.id
+)
+
+test_p2p_request = P2PRequestCrud(db).create(test_p2p_request_create_schema)
+
+
+class TestCreateP2PRequestRoute:
+
+    @staticmethod
+    def do_request(*args, **kwargs) -> Response:
+        return client.post('/p2p_request/create', *args, **kwargs)
+
+    def test_not_authorized(self):
+
+        response = self.do_request()
+
+        assert response.status_code == 401
+
+    def test_incorrect_scope(self):
+
+        response = self.do_request(data={
+            'username': test_p2p_user.username,
+            'password': test_p2p_user_create_schema.password,
+            'scope': 'incorrect_scope',
+        })
+
+        assert response.status_code == 401
+
+    def test_user_does_not_have_scope(self):
+
+        users_before_request = len(UserCrud(db).get_many())
+
+        with UserAccessCookie(client, test_p2p_user.username, ''):
+            response = self.do_request(params={
+                'username': 'test_incorrect_scope_user',
+                'password': 'test_incorrect_scope_user',
+                'discord_id': next(get_new_discord_id),
+            })
+
+        assert response.status_code == 401
+
+        assert users_before_request == len(UserCrud(db).get_many())
+
+
+class TestP2PRequestReview:
+
+    @staticmethod
+    def do_request(*args, **kwargs) -> Response:
+        return client.get('/p2p_request/review', *args, **kwargs)
+
+    def test_not_authorized(self):
+
+        response = self.do_request()
+
+        assert response.status_code == 401
+
+    def test_user_does_not_have_scope(self):
+
+        users_before_request = len(UserCrud(db).get_many())
+
+        with UserAccessCookie(client, test_p2p_user.username, ''):
+            response = self.do_request(params={
+                'username': 'test_incorrect_scope_user',
+                'password': 'test_incorrect_scope_user',
+                'discord_id': next(get_new_discord_id),
+            })
+
+        assert response.status_code == 401
+
+        assert users_before_request == len(UserCrud(db).get_many())

--- a/API/tests/test_p2p_request.py
+++ b/API/tests/test_p2p_request.py
@@ -25,11 +25,19 @@ test_p2p_user_create_schema = schemas.UserCreate(
 
 test_p2p_user = UserCrud(db).create(test_p2p_user_create_schema)
 
+test_reviewer_create_schema = schemas.UserCreate(
+    username='reviewer', password='reviewer_password', discord_id=next(get_new_discord_id)
+)
+
+test_reviewer = UserCrud(db).create(test_reviewer_create_schema)
+
 all_scopes = ScopeCrud(db).get_many()
 
 test_user_scope = all_scopes[2]
 
 UserToScopeCrud(db).create(schemas.UserToScopeCreate(user_id=test_p2p_user.id, scope_id=test_user_scope.id))
+
+UserToScopeCrud(db).create(schemas.UserToScopeCreate(user_id=test_reviewer.id, scope_id=test_user_scope.id))
 
 test_p2p_request_create_schema = schemas.P2PRequestCreate(
     repository_link='https://test-link', comment='test comment', creator_id=test_p2p_user.id
@@ -52,28 +60,38 @@ class TestCreateP2PRequestRoute:
 
     def test_incorrect_scope(self):
 
-        response = self.do_request(data={
-            'username': test_p2p_user.username,
-            'password': test_p2p_user_create_schema.password,
-            'scope': 'incorrect_scope',
-        })
+        with UserAccessCookie(client, test_p2p_user.username, 'me'):
+            response = self.do_request()
 
         assert response.status_code == 401
 
     def test_user_does_not_have_scope(self):
 
-        users_before_request = len(UserCrud(db).get_many())
+        user_crud = UserCrud(db)
+
+        users_before_request = len(user_crud.get_many())
 
         with UserAccessCookie(client, test_p2p_user.username, ''):
             response = self.do_request(params={
-                'username': 'test_incorrect_scope_user',
-                'password': 'test_incorrect_scope_user',
+                'username': test_p2p_user.username,
+                'password': test_p2p_user_create_schema.password,
                 'discord_id': next(get_new_discord_id),
             })
 
         assert response.status_code == 401
 
-        assert users_before_request == len(UserCrud(db).get_many())
+        assert users_before_request == len(user_crud.get_many())
+
+    def test_correct(self):
+
+        with UserAccessCookie(client, test_p2p_user.username, 'p2p_request'):
+            response = self.do_request(params={
+                'repository_link': test_p2p_request.repository_link,
+                'comment': test_p2p_request.comment
+            })
+
+        assert response.status_code == 200
+        assert response.json() is True
 
 
 class TestP2PRequestReview:
@@ -90,15 +108,59 @@ class TestP2PRequestReview:
 
     def test_user_does_not_have_scope(self):
 
-        users_before_request = len(UserCrud(db).get_many())
+        user_crud = UserCrud(db)
+
+        users_before_request = len(user_crud.get_many())
 
         with UserAccessCookie(client, test_p2p_user.username, ''):
             response = self.do_request(params={
-                'username': 'test_incorrect_scope_user',
-                'password': 'test_incorrect_scope_user',
+                'username': test_p2p_user.username,
+                'password': test_p2p_user_create_schema.password,
                 'discord_id': next(get_new_discord_id),
             })
 
         assert response.status_code == 401
 
-        assert users_before_request == len(UserCrud(db).get_many())
+        assert users_before_request == len(user_crud.get_many())
+
+    def test_user_gets_his_own_project(self):
+
+        with UserAccessCookie(client, test_p2p_user.username, 'p2p_request'):
+            response = self.do_request()
+
+        assert response.status_code == 200
+
+        assert response.json() == {'context': 'There are not any pending projects'}
+
+    def test_correct(self):
+
+        with UserAccessCookie(client, test_reviewer.username, 'p2p_request'):
+            response = self.do_request()
+
+        assert response.status_code == 200
+
+        oldest_project = P2PRequestCrud(db).start_review(test_reviewer.id)
+
+        p2p_request_schema = schemas.P2PRequest.model_validate(test_p2p_request)
+
+        assert p2p_request_schema.model_dump()['review_state'] != response.json()['review_state']
+
+        assert schemas.P2PRequest.model_validate(oldest_project).id == response.json()['id'] + 1
+
+    def test_user_already_have_review(self):
+
+        with UserAccessCookie(client, test_reviewer.username, 'p2p_request'):
+            response = self.do_request()
+
+        assert response.status_code == 200
+
+        assert response.json() == {'context': 'You already have a review, complete it first'}
+
+    def test_no_pending_projects(self):
+
+        with UserAccessCookie(client, test_p2p_user.username, 'p2p_request'):
+            response = self.do_request()
+
+        assert response.status_code == 200
+
+        assert response.json() == {'context': 'There are not any pending projects'}

--- a/API/tests/test_users.py
+++ b/API/tests/test_users.py
@@ -16,9 +16,6 @@ client = TestClient(app)
 
 db = get_db_not_dependency()
 
-for scope_name in SETTINGS.OAUTH2_SCHEME_SCOPES:
-    ScopeCrud(db).create(schemas.ScopeCreate(name=scope_name))
-
 test_user_1_create_schema = schemas.UserCreate(
     username='username_1', password='password_1', discord_id=next(get_new_discord_id)
 )


### PR DESCRIPTION
Пока что:

- **tests\test_p2p_request.py** - добавлена проверка авторизации и scope-a 'p2p-requst' у пользователя, создающего p2p-request и запрашивающего ревью

- из **tests\test_users.py** перенесла создание scopes в новый файл, потому что он выполняется первым (я так понимаю, файлы с тестами запускаются по алфавиту, и test_p2p_request.py самый первый, так что решила создавать scopes именно там)