### PR TITLE
fix: уязвимость в работе с сессиями базы данных

### DIFF
--- a/API/core/main.py
+++ b/API/core/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from sql import crud
-from sql.database import get_db, get_db_not_dependency
+from sql.database import get_db, SessionLocal
 from . import schemas
 from .config import get_settings
 from routers import system, users, p2p_request
@@ -16,13 +16,13 @@ SETTINGS = get_settings()
 @asynccontextmanager
 async def lifespan(_: FastAPI):
 
-    db = get_db_not_dependency()
+    with SessionLocal() as db:
 
-    all_scopes = [str(i) for i in crud.ScopeCrud(db).get_many()]
+        all_scopes = [str(i) for i in crud.ScopeCrud(db).get_many()]
 
-    for scope_name in SETTINGS.OAUTH2_SCHEME_SCOPES:
-        if scope_name not in all_scopes:
-            crud.ScopeCrud(db).create(schemas.ScopeCreate(name=scope_name))
+        for scope_name in SETTINGS.OAUTH2_SCHEME_SCOPES:
+            if scope_name not in all_scopes:
+                crud.ScopeCrud(db).create(schemas.ScopeCreate(name=scope_name))
 
     yield
 

--- a/API/pytest_runner.py
+++ b/API/pytest_runner.py
@@ -9,16 +9,16 @@ environ['IS_TEST'] = 'True'
 # (this causes settings setup)
 from subprocess import run
 
-from sql.database import get_db_not_dependency
+from sql.database import SessionLocal
 from sql.models import Base
 
 
-db = get_db_not_dependency()
+with SessionLocal() as db:
 
-for table in reversed(Base.metadata.tables.values()):
-    db.query(table).delete()
+    for table in reversed(Base.metadata.tables.values()):
+        db.query(table).delete()
 
-db.commit()
+    db.commit()
 
 run('alembic upgrade head', shell=True)
 run(f"python -m pytest {' '.join(argv[1:])}", shell=True)

--- a/API/routers/users.py
+++ b/API/routers/users.py
@@ -9,7 +9,7 @@ from passlib.context import CryptContext
 from fastapi_login.exceptions import InvalidCredentialsException
 
 from sql import crud, models
-from sql.database import get_db, get_db_not_dependency
+from sql.database import get_db, SessionLocal
 from core import schemas
 from core.config import get_settings
 from core.login_manager import login_manager
@@ -27,9 +27,18 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
     return pwd_context.verify(plain_password, hashed_password)
 
 
-@login_manager.user_loader()
-def get_user(username: str, db: Session = get_db_not_dependency()) -> models.User | None:
+def _get_user(username: str, db: Session) -> models.User | None:
     return crud.UserCrud(db).get(username=username)
+
+
+@login_manager.user_loader()
+def get_user(username: str, db: Session | None = None) -> models.User | None:
+
+    if not db:
+        with SessionLocal() as db:
+            return _get_user(username, db)
+
+    return _get_user(username, db)
 
 
 @router.post(f'/{SETTINGS.TOKEN_URL}', response_model=schemas.Token)

--- a/API/sql/database.py
+++ b/API/sql/database.py
@@ -16,8 +16,3 @@ Base = declarative_base()
 def get_db():
     with SessionLocal() as db:
         yield db
-
-
-def get_db_not_dependency() -> Session:
-    with SessionLocal() as db:
-        return db

--- a/API/tests/_testing_utils.py
+++ b/API/tests/_testing_utils.py
@@ -3,6 +3,16 @@ from typing import Generator
 from fastapi.testclient import TestClient
 
 from core.login_manager import login_manager
+from sql.database import SessionLocal
+
+
+class TestClientWithDb(TestClient):
+    def __init__(self, *args, **kwargs) -> None:
+
+        super().__init__(*args, **kwargs)
+
+        with SessionLocal() as db:
+            self.db = db
 
 
 class UserAccessCookie:

--- a/API/tests/test_users.py
+++ b/API/tests/test_users.py
@@ -1,36 +1,31 @@
-from fastapi.testclient import TestClient
 from httpx import Response
 
 from core.main import app
 from core.config import get_settings
 from core import schemas
 from sql.crud import UserCrud, ScopeCrud, UserToScopeCrud
-from sql.database import get_db_not_dependency
-from _testing_utils import UserAccessCookie, get_new_discord_id, get_field_detail_type
+from _testing_utils import TestClientWithDb, UserAccessCookie, get_new_discord_id, get_field_detail_type
 
 
 SETTINGS = get_settings()
 
-client = TestClient(app)
-
-
-db = get_db_not_dependency()
+client = TestClientWithDb(app)
 
 for scope_name in SETTINGS.OAUTH2_SCHEME_SCOPES:
-    ScopeCrud(db).create(schemas.ScopeCreate(name=scope_name))
+    ScopeCrud(client.db).create(schemas.ScopeCreate(name=scope_name))
 
 test_user_1_create_schema = schemas.UserCreate(
     username='username_1', password='password_1', discord_id=next(get_new_discord_id)
 )
 
-test_user_1 = UserCrud(db).create(test_user_1_create_schema)
+test_user_1 = UserCrud(client.db).create(test_user_1_create_schema)
 
-all_scopes = ScopeCrud(db).get_many()
+all_scopes = ScopeCrud(client.db).get_many()
 
 test_user_scope = all_scopes[0]
 not_test_user_scope = all_scopes[1]
 
-UserToScopeCrud(db).create(schemas.UserToScopeCreate(user_id=test_user_1.id, scope_id=test_user_scope.id))
+UserToScopeCrud(client.db).create(schemas.UserToScopeCreate(user_id=test_user_1.id, scope_id=test_user_scope.id))
 
 
 class TestLoginRoute:
@@ -128,7 +123,7 @@ class TestGetUserMeDataRoute:
         assert response.status_code == 200
 
         user_schema = schemas.User.model_validate(test_user_1)
-        user_schema.available_scopes = UserToScopeCrud(db).get_user_scopes(test_user_1)
+        user_schema.available_scopes = UserToScopeCrud(client.db).get_user_scopes(test_user_1)
 
         assert user_schema.model_dump() == response.json()
 
@@ -141,7 +136,7 @@ class TestCreateUserRoute:
 
     def test_empty(self):
 
-        users_before_request = len(UserCrud(db).get_many())
+        users_before_request = len(UserCrud(client.db).get_many())
 
         with UserAccessCookie(client, test_user_1.username, 'register'):
             response = self.do_request()
@@ -154,11 +149,11 @@ class TestCreateUserRoute:
         assert get_field_detail_type(response_details, 'password') == 'missing'
         assert get_field_detail_type(response_details, 'discord_id') == 'missing'
 
-        assert users_before_request == len(UserCrud(db).get_many())
+        assert users_before_request == len(UserCrud(client.db).get_many())
 
     def test_incorrect(self):
 
-        users_before_request = len(UserCrud(db).get_many())
+        users_before_request = len(UserCrud(client.db).get_many())
 
         with UserAccessCookie(client, test_user_1.username, 'register'):
             response = self.do_request(
@@ -171,11 +166,11 @@ class TestCreateUserRoute:
 
         assert get_field_detail_type(response_details, 'discord_id') == 'int_parsing'
 
-        assert users_before_request == len(UserCrud(db).get_many())
+        assert users_before_request == len(UserCrud(client.db).get_many())
 
     def test_duplicate_discord_id(self):
 
-        users_before_request = len(UserCrud(db).get_many())
+        users_before_request = len(UserCrud(client.db).get_many())
 
         with UserAccessCookie(client, test_user_1.username, 'register'):
             response = self.do_request(params={
@@ -186,11 +181,11 @@ class TestCreateUserRoute:
 
         assert response.status_code == 400
 
-        assert users_before_request == len(UserCrud(db).get_many())
+        assert users_before_request == len(UserCrud(client.db).get_many())
 
     def test_duplicate_username(self):
 
-        users_before_request = len(UserCrud(db).get_many())
+        users_before_request = len(UserCrud(client.db).get_many())
 
         with UserAccessCookie(client, test_user_1.username, 'register'):
             response = self.do_request(params={
@@ -201,7 +196,7 @@ class TestCreateUserRoute:
 
         assert response.status_code == 400
 
-        assert users_before_request == len(UserCrud(db).get_many())
+        assert users_before_request == len(UserCrud(client.db).get_many())
 
     def test_not_authorized(self):
 
@@ -211,7 +206,7 @@ class TestCreateUserRoute:
 
     def test_user_does_not_have_scope(self):
 
-        users_before_request = len(UserCrud(db).get_many())
+        users_before_request = len(UserCrud(client.db).get_many())
 
         with UserAccessCookie(client, test_user_1.username, ''):
             response = self.do_request(params={
@@ -222,11 +217,11 @@ class TestCreateUserRoute:
 
         assert response.status_code == 401
 
-        assert users_before_request == len(UserCrud(db).get_many())
+        assert users_before_request == len(UserCrud(client.db).get_many())
 
     def test_correct(self):
 
-        users_before_request = len(UserCrud(db).get_many())
+        users_before_request = len(UserCrud(client.db).get_many())
 
         test_correct_user_create_schema = schemas.UserCreate(
             username='test_correct_user', password='test_correct_user', discord_id=next(get_new_discord_id)
@@ -241,14 +236,14 @@ class TestCreateUserRoute:
 
         assert response.status_code == 200
 
-        assert users_before_request + 1 == len(UserCrud(db).get_many())
+        assert users_before_request + 1 == len(UserCrud(client.db).get_many())
 
-        test_correct_user_db = UserCrud(db).get(username=test_correct_user_create_schema.username)
+        test_correct_user_db = UserCrud(client.db).get(username=test_correct_user_create_schema.username)
 
         assert test_correct_user_db
         assert test_correct_user_db.discord_id == test_correct_user_create_schema.discord_id
 
         user_schema = schemas.User.model_validate(test_correct_user_db)
-        user_schema.available_scopes = UserToScopeCrud(db).get_user_scopes(test_correct_user_db)
+        user_schema.available_scopes = UserToScopeCrud(client.db).get_user_scopes(test_correct_user_db)
 
         assert user_schema.model_dump() == response.json()

--- a/API/utils.py
+++ b/API/utils.py
@@ -5,7 +5,7 @@ from typing import Callable
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 
-from sql.database import get_db_not_dependency
+from sql.database import SessionLocal
 from sql import crud
 from core import schemas
 
@@ -53,7 +53,8 @@ if __name__ == '__main__':
     if 'create_superuser' in argv and len(argv) == 5:
 
         try:
-            create_superuser(*argv[2:], db=get_db_not_dependency())
+            with SessionLocal() as db:
+                create_superuser(*argv[2:], db=db)
 
         except Exception as e:
             log_with_color(error, f'Something went wrong\n{e}', RED)


### PR DESCRIPTION
Восстановили изменения из https://github.com/LaGGgggg/yp_p2p_api/pull/13

> При использовании sql/database.py/get_db_not_dependency, сессия, открывавшаяся через with, закрывалась сразу же из-за return.
>
> sql/database.py/get_db_not_dependency: удалена get_db_not_dependency.
>
> Переработано для использования SessionLocal напрямую вместо get_db_not_dependency:
> core/main.py/lifespan
> pytest_runner.py
> routers/users.py/get_user
> utils.py
>
> tests/_testing_utils.py: добавлен TestClientWithDb (позволяет создать TestClient с сессией базы данных внутри).
> tests/test_users.py: переработано для использования TestClientWithDb вместо get_db_not_dependency.
4d837e3
API\core\main.py